### PR TITLE
Fix ADL-related regression, and use POSIX-compliant __linux__ define.

### DIFF
--- a/adl.c
+++ b/adl.c
@@ -9,7 +9,7 @@
 
 #include "config.h"
 
-#if defined(HAVE_ADL) && (defined(__linux) || defined (WIN32))
+#if defined(HAVE_ADL) && (defined(__linux__) || defined (WIN32))
 
 #include <stdio.h>
 #include <string.h>

--- a/configure.ac
+++ b/configure.ac
@@ -203,10 +203,15 @@ scrypt="no"
 if test "$found_opencl" = 1; then
 	if test "x$adl" != xno; then
 		ADL_CPPFLAGS=
+		dnl Look for ADL headers in a way that doesn't break cross-compile configs.
 		SAVED_CFLAGS=$CFLAGS
 		CFLAGS="$CFLAGS -I$srcdir"
+		dnl miner.h ensures LINUX is defined for native Linux compilation.
 		AC_CHECK_HEADER([ADL_SDK/adl_sdk.h], [have_adl=true; ADL_CPPFLAGS=-I$srcdir], [have_adl=false], 
-			[ [#include <stddef.h>] ])
+			[#if defined (__linux__) && !defined(LINUX)
+			 #  define LINUX
+			 #endif
+			 AC_INCLUDES_DEFAULT()])
 		CFLAGS=$SAVED_CFLAGS
 		if test x$have_adl+$have_cgminer_sdk = xfalse+true; then
 			AC_CHECK_HEADER([$CGMINER_SDK/include/ADL_SDK/adl_sdk.h], [have_adl=true; ADL_CPPFLAGS=-I$CGMINER_SDK/include], [have_adl=false],[])

--- a/miner.h
+++ b/miner.h
@@ -90,10 +90,8 @@ static inline int fsync (int fd)
 #endif
 #endif /* __MINGW32__ */
 
-#if defined (__linux)
- #ifndef LINUX
-  #define LINUX
- #endif
+#if defined (__linux__) && !defined(LINUX)
+# define LINUX
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
Autoconf change meant to address cross-compilation without breaking native Linux building (oops).  The ADL test failed if LINUX not defined, as normally set in miner.h, but wasn't set in autoconf test.

In the process, switch from obsolte non-POSIX-compiant **linux pre-processor macro to __linux** in a few spots.
